### PR TITLE
added container_name for mysql and kafka-connect

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
   kafka-connect:
     # remove or comment the following line for the Chapter 3 tutorial
     image: debezium/connect:2.3
+    container_name: kafka-connect
     # uncomment the following lines for the Chapter 3 tutorial
     # build:
     #   context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -109,6 +109,7 @@ services:
 
   mysql:
     image: mysql:8.0
+    container_name: mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: secret


### PR DESCRIPTION
added the container_name field to the mysql container. This way it aligns correctly with the redpanda university documentation. The documentation uses the example below, which indicates the mysql container should have a name of "mysql", but without the container_name field, it will not be assigned that name.

alias mysql="docker-compose exec -ti mysql mysql ... "
